### PR TITLE
Modified how the topology distributions are handled

### DIFF
--- a/src/main/java/com/net2plan/gui/utils/topologyPane/TopologyPanel.java
+++ b/src/main/java/com/net2plan/gui/utils/topologyPane/TopologyPanel.java
@@ -35,7 +35,7 @@ import com.net2plan.gui.utils.WiderJComboBox;
 import com.net2plan.gui.utils.topologyPane.jung.AddLinkGraphPlugin;
 import com.net2plan.gui.utils.topologyPane.jung.JUNGCanvas;
 import com.net2plan.gui.utils.topologyPane.utils.MenuButton;
-import com.net2plan.gui.utils.windows.WindowController;
+import com.net2plan.gui.utils.viewEditWindows.WindowController;
 import com.net2plan.interfaces.networkDesign.Net2PlanException;
 import com.net2plan.interfaces.networkDesign.NetPlan;
 import com.net2plan.interfaces.networkDesign.NetworkLayer;

--- a/src/main/java/com/net2plan/gui/utils/topologyPane/jung/topologyDistribution/CircularDistribution.java
+++ b/src/main/java/com/net2plan/gui/utils/topologyPane/jung/topologyDistribution/CircularDistribution.java
@@ -1,0 +1,47 @@
+package com.net2plan.gui.utils.topologyPane.jung.topologyDistribution;
+
+import com.net2plan.interfaces.networkDesign.Node;
+
+import java.awt.geom.Point2D;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Jorge San Emeterio
+ * @date 07-Dec-16
+ */
+public class CircularDistribution implements ITopologyDistribution
+{
+    @Override
+    public Map<Long, Point2D> getNodeDistribution(List<Node> nodes)
+    {
+        final Map<Long, Point2D> nodeDistribution = new HashMap<>();
+
+        final int maxAng = 360;
+
+        final int minWidth = 320;
+        final int minHeight = 320;
+
+        final int width = 30 * nodes.size();
+        final int height = 30 * nodes.size();
+
+        final int finalWidth = width < minWidth ? minWidth : width;
+        final int finalHeight = height < minHeight ? minHeight : height;
+
+        // Distribute nodes along a circle
+        for (int i = 0; i < nodes.size(); i++)
+        {
+            final Node node = nodes.get(i);
+
+            final int ang = (i + 1) * (maxAng / nodes.size());
+
+            final int x = (int) (finalWidth * Math.cos(Math.toRadians(ang)));
+            final int y = (int) (finalHeight * Math.sin(Math.toRadians(ang)));
+
+            nodeDistribution.put(node.getId(), new Point2D.Double(x, y));
+        }
+
+        return nodeDistribution;
+    }
+}

--- a/src/main/java/com/net2plan/gui/utils/topologyPane/jung/topologyDistribution/ITopologyDistribution.java
+++ b/src/main/java/com/net2plan/gui/utils/topologyPane/jung/topologyDistribution/ITopologyDistribution.java
@@ -1,0 +1,16 @@
+package com.net2plan.gui.utils.topologyPane.jung.topologyDistribution;
+
+import com.net2plan.interfaces.networkDesign.Node;
+
+import java.awt.geom.Point2D;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Jorge San Emeterio
+ * @date 07-Dec-16
+ */
+public interface ITopologyDistribution
+{
+    Map<Long, Point2D> getNodeDistribution(final List<Node> nodes);
+}

--- a/src/main/java/com/net2plan/gui/utils/viewEditWindows/WindowController.java
+++ b/src/main/java/com/net2plan/gui/utils/viewEditWindows/WindowController.java
@@ -1,6 +1,6 @@
-package com.net2plan.gui.utils.windows;
+package com.net2plan.gui.utils.viewEditWindows;
 
-import com.net2plan.gui.utils.windows.parent.GUIWindow;
+import com.net2plan.gui.utils.viewEditWindows.parent.GUIWindow;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/com/net2plan/gui/utils/viewEditWindows/parent/GUIWindow.java
+++ b/src/main/java/com/net2plan/gui/utils/viewEditWindows/parent/GUIWindow.java
@@ -1,7 +1,7 @@
-package com.net2plan.gui.utils.windows.parent;
+package com.net2plan.gui.utils.viewEditWindows.parent;
 
 import com.net2plan.gui.GUINet2Plan;
-import com.net2plan.gui.utils.windows.utils.WindowUtils;
+import com.net2plan.gui.utils.viewEditWindows.utils.WindowUtils;
 import com.net2plan.interfaces.networkDesign.Net2PlanException;
 
 import javax.swing.*;

--- a/src/main/java/com/net2plan/gui/utils/viewEditWindows/utils/WindowUtils.java
+++ b/src/main/java/com/net2plan/gui/utils/viewEditWindows/utils/WindowUtils.java
@@ -1,4 +1,4 @@
-package com.net2plan.gui.utils.windows.utils;
+package com.net2plan.gui.utils.viewEditWindows.utils;
 
 import com.net2plan.gui.GUINet2Plan;
 


### PR DESCRIPTION
The way the topology layouts are handled has been simplied.

The interface ITopologyDistribution defines the method that each topology distribution must implement to give the desired layout.
Updating the topology layout is no longer needed when a node is added or removed.