### PR TITLE
BuiltInExamples.jar shows up as the default jar again

### DIFF
--- a/Net2Plan-GUI/Net2Plan-GUI-Exec/src/main/java/com/net2plan/gui/utils/RunnableSelector.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Exec/src/main/java/com/net2plan/gui/utils/RunnableSelector.java
@@ -260,7 +260,9 @@ public class RunnableSelector extends JPanel {
     private void getDefaults() {
         try {
             String defaultRunnableCodePath = Configuration.getOption("defaultRunnableCodePath");
+            defaultRunnableCodePath = defaultRunnableCodePath.replace("#path# ", "");
             File file = new File(defaultRunnableCodePath);
+
             if (!file.exists() || file.isDirectory()) return;
 
             if (file.getName().toLowerCase(Locale.getDefault()).endsWith(".jar") || file.getName().toLowerCase(Locale.getDefault()).endsWith(".class"))


### PR DESCRIPTION
- BuiltInExamples loads up again as the default algorithm container at the algorithm selector.