### PR TITLE
Fixing Javadoc issues

### DIFF
--- a/Net2Plan-Javadoc/pom.xml
+++ b/Net2Plan-Javadoc/pom.xml
@@ -92,6 +92,7 @@
                             <links>
                                 <link>../parallelcolt</link>
                             </links>
+                            <detectOfflineLinks>false</detectOfflineLinks>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
                                 <!-- Net2Plan Core-->
@@ -134,6 +135,7 @@
                             <links>
                                 <link>../parallelcolt</link>
                             </links>
+                            <detectOfflineLinks>false</detectOfflineLinks>
                             <tagletArtifact>
                                 <groupId>com.net2plan</groupId>
                                 <artifactId>net2plan-javadoc</artifactId>
@@ -188,6 +190,7 @@
                                 <artifactId>net2plan-javadoc</artifactId>
                                 <version>0.5.1-SNAPSHOT</version>
                             </docletArtifact>
+                            <detectOfflineLinks>false</detectOfflineLinks>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
                                 <!-- Net2Plan Examples-->
@@ -221,6 +224,7 @@
                                 <artifactId>net2plan-javadoc</artifactId>
                                 <version>0.5.1-SNAPSHOT</version>
                             </docletArtifact>
+                            <detectOfflineLinks>false</detectOfflineLinks>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
                                 <!-- Net2Plan Examples-->

--- a/Net2Plan-Javadoc/src/assembly/javadoc-descriptor.xsl
+++ b/Net2Plan-Javadoc/src/assembly/javadoc-descriptor.xsl
@@ -19,5 +19,10 @@
             <outputDirectory>api/doc-files</outputDirectory>
             <useDefaultExcludes>true</useDefaultExcludes>
         </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/resources/resources/documentation</directory>
+            <outputDirectory>examples/doc-files</outputDirectory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.sun</groupId>
             <artifactId>tools</artifactId>
-            <version>1.4.2</version>
+            <version>1.8</version>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>


### PR DESCRIPTION
- Javadoc no longer throws warnings during its creation.
- Added book cover to examples Javadoc