### PR TITLE
Added forwarding rule focus panel

### DIFF
--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -1,26 +1,50 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2017 Pablo Pavon-Marino.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the GNU Lesser Public License v3.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.gnu.org/licenses/lgpl.html
+ *  *
+ *  * Contributors:
+ *  *     Pablo Pavon-Marino - Jose-Luis Izquierdo-Zaragoza, up to version 0.3.1
+ *  *     Pablo Pavon-Marino - from version 0.4.0 onwards
+ *  *     Pablo Pavon Marino - Jorge San Emeterio Villalain, from version 0.4.1 onwards
+ *  *****************************************************************************
+ */
+
 package com.net2plan.gui.plugins.networkDesign.focusPane;
 
 import com.net2plan.gui.plugins.GUINetworkDesign;
+import com.net2plan.interfaces.networkDesign.Demand;
+import com.net2plan.interfaces.networkDesign.Link;
 import com.net2plan.interfaces.networkDesign.NetworkLayer;
-import com.net2plan.interfaces.networkDesign.Node;
+import com.net2plan.utils.Pair;
 
 import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
 
-public class FigureNodeSequencePanel extends FigureSequencePanel
+/**
+ * @author Jorge San Emeterio Villalain
+ * @date 4/04/17
+ */
+public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
 {
-    private DrawNode dn;
+    private Pair<Demand, Link> forwardingRule;
+    private NetworkLayer networkLayer;
     private List<String> generalMessage;
-    private Node node;
-    private NetworkLayer layer;
     private Dimension preferredSize;
 
-    public FigureNodeSequencePanel(GUINetworkDesign callback, Node node, NetworkLayer layer, String... titleMessage)
+    public FigureForwardingRuleSequencePanel(GUINetworkDesign callback, Pair<Demand, Link> forwardingRule, NetworkLayer networkLayer, String... titleMessage)
     {
         super(callback);
-        this.layer = layer;
-        this.node = node;
+
+        assert forwardingRule != null;
+        assert networkLayer != null;
+
+        this.forwardingRule = forwardingRule;
+        this.networkLayer = networkLayer;
         this.generalMessage = Arrays.asList(titleMessage);
         this.preferredSize = null;
     }
@@ -60,11 +84,9 @@ public class FigureNodeSequencePanel extends FigureSequencePanel
         final int topCoordinateLineNodes = currentXYStartOfText + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels);
         final Point initialDnTopLeftPosition = new Point(maxHeightOrSizeIcon, topCoordinateLineNodes);
 
-    	/* Initial dn */
-        dn = new DrawNode(node, layer, maxHeightOrSizeIcon);
+        DrawNode dn = new DrawNode(forwardingRule.getSecond().getOriginNode(), networkLayer, maxHeightOrSizeIcon);
         final Dimension windowDimension = DrawNode.addNodeToGraphics(g2d , dn , initialDnTopLeftPosition , fontMetrics , regularInterlineSpacePixels , null);
         drawnNodes.add(dn);
         preferredSize = new Dimension (windowDimension.width + XYMARGIN , windowDimension.height + XYMARGIN);
     }
 }
-

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -19,6 +19,7 @@ import com.net2plan.gui.plugins.GUINetworkDesign;
 import com.net2plan.interfaces.networkDesign.Demand;
 import com.net2plan.interfaces.networkDesign.Link;
 import com.net2plan.interfaces.networkDesign.NetworkLayer;
+import com.net2plan.interfaces.networkDesign.Node;
 import com.net2plan.utils.Pair;
 
 import java.awt.*;
@@ -35,6 +36,20 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
     private NetworkLayer networkLayer;
     private List<String> generalMessage;
     private Dimension preferredSize;
+
+    private final int ICON_JUMP = 5;
+    private final int LINE_JUMP = 1;
+
+    private final Font plainFont = new Font("Arial", Font.PLAIN, 10);
+    private final Font headerFont = new Font("Arial", Font.BOLD, 12);
+
+    private final BasicStroke lineStroke = new BasicStroke(1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, new float[]{10.0f}, 0.0f);
+
+    private int textRow = 0;
+    private int iconRow = 0;
+
+    private final int maxIconSize = 40;
+    private final int maxNumberOfTagsPerNodeNorResource = 1;
 
     public FigureForwardingRuleSequencePanel(GUINetworkDesign callback, Pair<Demand, Link> forwardingRule, NetworkLayer networkLayer, String... titleMessage)
     {
@@ -61,32 +76,143 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
         final Graphics2D g2d = (Graphics2D) graphics;
         g2d.setColor(Color.black);
 
-        int currentXYStartOfText = 40;
-        final int maxHeightOrSizeIcon = 60;
-        final int maxNumberOfTagsPerNodeNorResource = 1;
-
     	/* Initial messages */
-        g2d.setFont(new Font("Arial", Font.BOLD, 12));
+        g2d.setFont(headerFont);
         final int fontHeightTitle = g2d.getFontMetrics().getHeight();
-        for (int indexMessage = 0; indexMessage < generalMessage.size(); indexMessage++)
+        for (String s : generalMessage)
         {
-            final String m = generalMessage.get(indexMessage);
-            g2d.drawString(m, currentXYStartOfText, currentXYStartOfText);
-            currentXYStartOfText += fontHeightTitle;
+            g2d.drawString(s, maxIconSize, maxIconSize + (textRow) * fontHeightTitle);
+            textRow = addLineJump(textRow);
         }
 
-        currentXYStartOfText += 15; // separation main message to first info nodes
+        // Drawing node
+        drawNode(g2d);
 
-        g2d.setFont(new Font("Arial", Font.PLAIN, 10));
+        // Drawing demand
+        drawDemand(g2d);
+
+        // Drawing link
+        drawLink(g2d);
+    }
+
+    private void drawNode(Graphics2D g2d)
+    {
+        g2d.setFont(headerFont);
+        FontMetrics fontMetrics = g2d.getFontMetrics();
+        int regularInterlineSpacePixels = fontMetrics.getHeight();
+
+        // Draw node header
+        final Node originNode = forwardingRule.getSecond().getOriginNode();
+        textRow = addLineJump(textRow);
+        g2d.drawString("Node " + originNode.getIndex(), maxIconSize, maxIconSize + (regularInterlineSpacePixels * (textRow)));
+
+        // Drawing node
+        g2d.setFont(plainFont);
+        fontMetrics = g2d.getFontMetrics();
+        regularInterlineSpacePixels = fontMetrics.getHeight();
+
+        iconRow = textRow;
+        iconRow = addLineJump(iconRow);
+
+        int topCoordinateLineNodes = maxIconSize + (generalMessage.size() * regularInterlineSpacePixels) + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels) * iconRow;
+        Point initialDnTopLeftPosition = new Point(maxIconSize, topCoordinateLineNodes);
+
+        DrawNode dn = new DrawNode(originNode, networkLayer, maxIconSize);
+        DrawNode.addNodeToGraphics(g2d, dn, initialDnTopLeftPosition, fontMetrics, regularInterlineSpacePixels, null);
+        drawnNodes.add(dn);
+    }
+
+    private void drawDemand(Graphics2D g2d)
+    {
         final FontMetrics fontMetrics = g2d.getFontMetrics();
         final int regularInterlineSpacePixels = fontMetrics.getHeight();
 
-        final int topCoordinateLineNodes = currentXYStartOfText + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels);
-        final Point initialDnTopLeftPosition = new Point(maxHeightOrSizeIcon, topCoordinateLineNodes);
+        final Demand demand = forwardingRule.getFirst();
+        final Node demandIngress = demand.getIngressNode();
+        final Node demandEgress = demand.getEgressNode();
 
-        DrawNode dn = new DrawNode(forwardingRule.getSecond().getOriginNode(), networkLayer, maxHeightOrSizeIcon);
-        final Dimension windowDimension = DrawNode.addNodeToGraphics(g2d , dn , initialDnTopLeftPosition , fontMetrics , regularInterlineSpacePixels , null);
-        drawnNodes.add(dn);
-        preferredSize = new Dimension (windowDimension.width + XYMARGIN , windowDimension.height + XYMARGIN);
+        final DrawNode ingressNode = new DrawNode(demandIngress, demand.getLayer(), maxIconSize);
+        final DrawNode egressNode = new DrawNode(demandEgress, demand.getLayer(), maxIconSize);
+
+        textRow = addIconJump(textRow);
+        textRow = addLineJump(textRow);
+
+        iconRow = addLineJump(textRow);
+        iconRow = addLineJump(iconRow);
+
+        int topCoordinateLineNodes = maxIconSize + (generalMessage.size() * regularInterlineSpacePixels) + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels) * iconRow;
+        Point initialDnTopLeftPosition = new Point(maxIconSize, topCoordinateLineNodes);
+        int xSeparationDnCenters = maxIconSize * 3;
+
+        g2d.setFont(headerFont);
+        g2d.drawString("Demand " + demand.getIndex(), maxIconSize, maxIconSize + (regularInterlineSpacePixels * (textRow)));
+
+        g2d.setFont(plainFont);
+
+        DrawNode.addNodeToGraphics(g2d, ingressNode, initialDnTopLeftPosition, fontMetrics, regularInterlineSpacePixels, null);
+        DrawNode.addNodeToGraphics(g2d, egressNode, new Point(initialDnTopLeftPosition.x + xSeparationDnCenters, initialDnTopLeftPosition.y), fontMetrics, regularInterlineSpacePixels, null);
+
+        drawnNodes.add(ingressNode);
+        drawnNodes.add(egressNode);
+
+        final DrawLine demandDL = new DrawLine(ingressNode, egressNode, ingressNode.posEast(), egressNode.posWest());
+        DrawLine.addLineToGraphics(g2d, demandDL, fontMetrics, regularInterlineSpacePixels, lineStroke);
+    }
+
+    private void drawLink(Graphics2D g2d)
+    {
+        final FontMetrics fontMetrics = g2d.getFontMetrics();
+        final int regularInterlineSpacePixels = fontMetrics.getHeight();
+
+        final Link link = forwardingRule.getSecond();
+        final Node linkOrigin = link.getOriginNode();
+        final Node linkDestination = link.getDestinationNode();
+
+        final DrawNode originNode = new DrawNode(linkOrigin, link.getLayer(), maxIconSize);
+        final DrawNode destinationNode = new DrawNode(linkDestination, link.getLayer(), maxIconSize);
+
+        textRow = addIconJump(textRow);
+        textRow = addLineJump(textRow);
+
+        iconRow = addLineJump(textRow);
+        iconRow = addLineJump(iconRow);
+
+        int topCoordinateLineNodes = maxIconSize + (generalMessage.size() * regularInterlineSpacePixels) + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels) * iconRow;
+        Point initialDnTopLeftPosition = new Point(maxIconSize, topCoordinateLineNodes);
+        int xSeparationDnCenters = maxIconSize * 3;
+
+        g2d.setFont(headerFont);
+        g2d.drawString("Link " + link.getIndex(), maxIconSize, maxIconSize + (regularInterlineSpacePixels * (textRow)));
+
+        g2d.setFont(plainFont);
+
+        DrawNode.addNodeToGraphics(g2d, originNode, initialDnTopLeftPosition, fontMetrics, regularInterlineSpacePixels, null);
+        DrawNode.addNodeToGraphics(g2d, destinationNode, new Point(initialDnTopLeftPosition.x + xSeparationDnCenters, initialDnTopLeftPosition.y), fontMetrics, regularInterlineSpacePixels, null);
+
+        drawnNodes.add(originNode);
+        drawnNodes.add(destinationNode);
+
+        final DrawLine LinkDL = new DrawLine(originNode, destinationNode, originNode.posEast(), destinationNode.posWest());
+        DrawLine.addLineToGraphics(g2d, LinkDL, fontMetrics, regularInterlineSpacePixels, lineStroke);
+    }
+
+    private int addIconJump(int graphicsRow)
+    {
+        return graphicsRow + ICON_JUMP;
+    }
+
+    private int addLineJump(int graphicsRow)
+    {
+        return graphicsRow + LINE_JUMP;
+    }
+
+    private int removeIconJump(int graphicsRow)
+    {
+        return graphicsRow - ICON_JUMP;
+    }
+
+    private int removeLineJump(int graphicsRow)
+    {
+        return graphicsRow - LINE_JUMP;
     }
 }

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -195,8 +195,9 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
         drawnNodes.add(originNode);
         drawnNodes.add(destinationNode);
 
-        final DrawLine LinkDL = new DrawLine(originNode, destinationNode, originNode.posEast(), destinationNode.posWest());
-        DrawLine.addLineToGraphics(g2d, LinkDL, fontMetrics, regularInterlineSpacePixels, lineStroke);
+        final DrawLine linkDL = new DrawLine(originNode, destinationNode, link, originNode.posEast(), destinationNode.posWest(), link.getOccupiedCapacity());
+        DrawLine.addLineToGraphics(g2d, linkDL, fontMetrics, regularInterlineSpacePixels);
+        drawnLines.add(linkDL);
         preferredSize = new Dimension(windowDimension.width + XYMARGIN, windowDimension.height + XYMARGIN);
     }
 

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -111,6 +111,8 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
 
         // Drawing node
         g2d.setFont(plainFont);
+        fontMetrics = g2d.getFontMetrics();
+        regularInterlineSpacePixels = fontMetrics.getHeight();
 
         iconRow = textRow;
         iconRow = addLineJump(iconRow);

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -187,13 +187,14 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
         g2d.setFont(plainFont);
 
         DrawNode.addNodeToGraphics(g2d, originNode, initialDnTopLeftPosition, fontMetrics, regularInterlineSpacePixels, null);
-        DrawNode.addNodeToGraphics(g2d, destinationNode, new Point(initialDnTopLeftPosition.x + xSeparationDnCenters, initialDnTopLeftPosition.y), fontMetrics, regularInterlineSpacePixels, null);
+        final Dimension windowDimension = DrawNode.addNodeToGraphics(g2d, destinationNode, new Point(initialDnTopLeftPosition.x + xSeparationDnCenters, initialDnTopLeftPosition.y), fontMetrics, regularInterlineSpacePixels, null);
 
         drawnNodes.add(originNode);
         drawnNodes.add(destinationNode);
 
         final DrawLine LinkDL = new DrawLine(originNode, destinationNode, originNode.posEast(), destinationNode.posWest());
         DrawLine.addLineToGraphics(g2d, LinkDL, fontMetrics, regularInterlineSpacePixels, lineStroke);
+        preferredSize = new Dimension(windowDimension.width + XYMARGIN, windowDimension.height + XYMARGIN);
     }
 
     private int addIconJump(int graphicsRow)

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -135,11 +135,11 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
         final DrawNode ingressNode = new DrawNode(demandIngress, demand.getLayer(), maxIconSize);
         final DrawNode egressNode = new DrawNode(demandEgress, demand.getLayer(), maxIconSize);
 
-        textRow = addIconJump(textRow);
+        textRow = addIconJump(iconRow);
+        textRow = addLineJump(textRow);
         textRow = addLineJump(textRow);
 
         iconRow = addLineJump(textRow);
-        iconRow = addLineJump(iconRow);
 
         int topCoordinateLineNodes = maxIconSize + (generalMessage.size() * regularInterlineSpacePixels) + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels) * iconRow;
         Point initialDnTopLeftPosition = new Point(maxIconSize, topCoordinateLineNodes);
@@ -172,11 +172,11 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
         final DrawNode originNode = new DrawNode(linkOrigin, link.getLayer(), maxIconSize);
         final DrawNode destinationNode = new DrawNode(linkDestination, link.getLayer(), maxIconSize);
 
-        textRow = addIconJump(textRow);
+        textRow = addIconJump(iconRow);
+        textRow = addLineJump(textRow);
         textRow = addLineJump(textRow);
 
         iconRow = addLineJump(textRow);
-        iconRow = addLineJump(iconRow);
 
         int topCoordinateLineNodes = maxIconSize + (generalMessage.size() * regularInterlineSpacePixels) + (maxNumberOfTagsPerNodeNorResource * regularInterlineSpacePixels) * iconRow;
         Point initialDnTopLeftPosition = new Point(maxIconSize, topCoordinateLineNodes);

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureForwardingRuleSequencePanel.java
@@ -76,6 +76,9 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
         final Graphics2D g2d = (Graphics2D) graphics;
         g2d.setColor(Color.black);
 
+        textRow = 0;
+        iconRow = 0;
+
     	/* Initial messages */
         g2d.setFont(headerFont);
         final int fontHeightTitle = g2d.getFontMetrics().getHeight();
@@ -108,8 +111,6 @@ public class FigureForwardingRuleSequencePanel extends FigureSequencePanel
 
         // Drawing node
         g2d.setFont(plainFont);
-        fontMetrics = g2d.getFontMetrics();
-        regularInterlineSpacePixels = fontMetrics.getHeight();
 
         iconRow = textRow;
         iconRow = addLineJump(iconRow);

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureSRGSequencePanel.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FigureSRGSequencePanel.java
@@ -79,13 +79,19 @@ public class FigureSRGSequencePanel extends FigureSequencePanel
         Point initialDnTopLeftPosition = new Point(maxIconSize, topCoordinateLineNodes);
         int xSeparationDnCenters = maxIconSize * 3;
 
+        int maxWidth = 0;
+        int maxHeight = 0;
+
         // Drawing nodes
         int graphicsColumn = 0;
         for (Node node : riskGroup.getNodes())
         {
             final DrawNode drawNode = new DrawNode(node, callback.getDesign().getNetworkLayerDefault(), maxIconSize);
             drawnNodes.add(drawNode);
-            DrawNode.addNodeToGraphics(g2d, drawNode, new Point(initialDnTopLeftPosition.x + (xSeparationDnCenters * (graphicsColumn++)), initialDnTopLeftPosition.y), fontMetrics, regularInterlineSpacePixels, null);
+            final Dimension dimension = DrawNode.addNodeToGraphics(g2d, drawNode, new Point(initialDnTopLeftPosition.x + (xSeparationDnCenters * (graphicsColumn++)), initialDnTopLeftPosition.y), fontMetrics, regularInterlineSpacePixels, null);
+
+            if (dimension.width > maxWidth) maxWidth = dimension.width + XYMARGIN;
+            if (dimension.height > maxHeight) maxHeight = dimension.height + XYMARGIN;
         }
 
         // Draw layers
@@ -103,9 +109,6 @@ public class FigureSRGSequencePanel extends FigureSequencePanel
         // Icons two rows below the text
         iconRow = addLineJump(textRow);
         iconRow = addLineJump(iconRow);
-
-        int maxWidth = 0;
-        int maxHeight = 0;
 
         // Drawing each layer
         // NOTE: Random order

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FocusPane.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FocusPane.java
@@ -66,8 +66,8 @@ public class FocusPane extends JPanel
 		else if (elementType == NetworkElementType.FORWARDING_RULE)
 		{
 			final Pair<Demand,Link> fr = vs.getPickedForwardingRule();
-//			final LinkSequencePanel fig = new LinkSequencePanel(r.getPath() , r.getLayer() , r.getSeqOccupiedCapacitiesIfNotFailing() , "Route " + r.getIndex() , r.getCarriedTraffic());
-//			this.add(fig , BorderLayout.WEST);
+			final FigureForwardingRuleSequencePanel fig = new FigureForwardingRuleSequencePanel(callback, fr, callback.getDesign().getNetworkLayerDefault(), "Node " + fr.getSecond().getOriginNode().getIndex());
+			this.add(fig , BorderLayout.WEST);
 			this.add(createPanelInfo(getForwardingRuleInfoTables(fr), null) , BorderLayout.CENTER);
 		}
 		else if (elementType == NetworkElementType.LAYER)

--- a/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FocusPane.java
+++ b/Net2Plan-GUI/Net2Plan-GUI-Plugins/Net2Plan-NetworkDesign/src/main/java/com/net2plan/gui/plugins/networkDesign/focusPane/FocusPane.java
@@ -66,7 +66,7 @@ public class FocusPane extends JPanel
 		else if (elementType == NetworkElementType.FORWARDING_RULE)
 		{
 			final Pair<Demand,Link> fr = vs.getPickedForwardingRule();
-			final FigureForwardingRuleSequencePanel fig = new FigureForwardingRuleSequencePanel(callback, fr, callback.getDesign().getNetworkLayerDefault(), "Node " + fr.getSecond().getOriginNode().getIndex());
+			final FigureForwardingRuleSequencePanel fig = new FigureForwardingRuleSequencePanel(callback, fr, callback.getDesign().getNetworkLayerDefault(), "Forwarding rule");
 			this.add(fig , BorderLayout.WEST);
 			this.add(createPanelInfo(getForwardingRuleInfoTables(fr), null) , BorderLayout.CENTER);
 		}


### PR DESCRIPTION
- Forwarding rules focus panel was missing. Added one for this element.
- The panel shows the node, demand and link of the forwarding rule.
- Fixed: Recalculated SRG focus panel size in case only a node is displayed.