### PR TITLE
Added license download to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ script:
   mvn clean package
 
 after_success:
-  echo $SUCCESSMESSAGE
+  echo "Build successful. Awesome!"
 
 after_failure:
-  echo $ERRORMESSAGE
+  echo "Build finished with errors. Bollocks!"
 
 notifications:
   email: true

--- a/Net2Plan-Assembly/pom.xml
+++ b/Net2Plan-Assembly/pom.xml
@@ -94,6 +94,27 @@
     <build>
         <finalName>Net2Plan-${project.version}</finalName>
         <plugins>
+            <!-- Download licenses -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.12</version>
+                <executions>
+                    <execution>
+                        <id>download-licenses</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>download-licenses</goal>
+                        </goals>
+                        <configuration>
+                            <excludedGroups>com.net2plan</excludedGroups>
+                            <excludedScopes>test</excludedScopes>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <quiet>true</quiet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Plugin required to assemble the project for distribution  -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/Net2Plan-Assembly/src/assembly/assembler.xsl
+++ b/Net2Plan-Assembly/src/assembly/assembler.xsl
@@ -1,4 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 
     <id>distribution</id>
 
@@ -7,6 +9,7 @@
     </formats>
 
     <fileSets>
+        <!-- Add info files -->
         <fileSet>
             <directory>${project.parent.basedir}</directory>
             <outputDirectory/>
@@ -15,6 +18,14 @@
                 <include>LICENSE*</include>
                 <include>NOTICE*</include>
                 <include>CHANGELOG*</include>
+            </includes>
+        </fileSet>
+        <!-- Add licenses -->
+        <fileSet>
+            <directory>${project.build.directory}/generated-resources</directory>
+            <outputDirectory>lib/</outputDirectory>
+            <includes>
+                <include>**</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
- As a requirement that Maven did not provide, Maven now downloads all the dependencies' licenses during the build and saves them under lib/licenses
- An index file is also generated indicating which library has which license.